### PR TITLE
fix close button position not in the center

### DIFF
--- a/src/styles.css
+++ b/src/styles.css
@@ -128,6 +128,7 @@
   color: #ffff;
   font-size: 25px;
   font-weight: lighter;
+  display: flex;
   text-align: center;
   vertical-align: top;
   background: #ffff;


### PR DESCRIPTION
Fix the close button position not in the center
Before: 
![close-btn-issue](https://github.com/waskito/react-modal-videojs/assets/23297498/23837881-9866-4a72-ba7a-fe8fd7c7909c)
After:
![close-btn-solved](https://github.com/waskito/react-modal-videojs/assets/23297498/137888da-4aa1-4962-8966-ea762a38a35d)
